### PR TITLE
In write to INTENA, the ipl[3] was activated without the enable bit set

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Since much of the initial work and testing for the PiStorm was done on Amiga com
 
 # Simple quickstart
 
-* Download Raspberry Pi OS from https://www.raspberrypi.org/software/operating-systems/, the Lite version is recommended as the windowing system of the Full version adds a lot of extra system load which may impact performance.
+* Download Raspberry Pi OS from https://www.raspberrypi.org/software/operating-systems/, the Lite version is recommended as the windowing system of the Full version adds a lot of extra system load which may impact performance. **Note: You must use the 32bit version of Pi OS.** 
 * Write the Image to a SD Card. 8GB is plenty for the PiStorm binaries and required libraries, but if you wish to use large hard drive images or sometthing with it, go with a bigger card.
 * Install the PiStorm adapter in place of the orignal CPU in the system, for instance an Amiga 500.
   Make sure the PiStorm sits flush and correct in the socket.

--- a/emulator.c
+++ b/emulator.c
@@ -1145,13 +1145,13 @@ void m68k_write_memory_16(unsigned int address, unsigned int value) {
     return;
 
   if (address & 0x01) {
-    ps_write_8(value & 0xFF, address);
-    ps_write_8((value >> 8) & 0xFF, address + 1);
+    ps_write_8((uint32_t)address, value & 0xFF);
+    ps_write_8((uint32_t)address + 1, (value >> 8) & 0xFF);
+    return;
+  } else {
+    ps_write_16((uint32_t)address, value);
     return;
   }
-
-  ps_write_16((uint32_t)address, value);
-  return;
 }
 
 void m68k_write_memory_32(unsigned int address, unsigned int value) {
@@ -1162,13 +1162,13 @@ void m68k_write_memory_32(unsigned int address, unsigned int value) {
     return;
 
   if (address & 0x01) {
-    ps_write_8(value & 0xFF, address);
-    ps_write_16(htobe16(((value >> 8) & 0xFFFF)), address + 1);
-    ps_write_8((value >> 24), address + 3);
+    ps_write_8((uint32_t)address, value & 0xFF);
+    ps_write_16((uint32_t)address + 1, htobe16(((value >> 8) & 0xFFFF)));
+    ps_write_8((uint32_t)address + 3, (value >> 24));
+    return;
+  } else {
+    ps_write_16((uint32_t)address, value >> 16);
+    ps_write_16((uint32_t)address + 2, value);
     return;
   }
-
-  ps_write_16(address, value >> 16);
-  ps_write_16(address + 2, value);
-  return;
 }

--- a/emulator.c
+++ b/emulator.c
@@ -1038,7 +1038,7 @@ static inline int32_t platform_write_check(uint8_t type, uint32_t addr, uint32_t
             ipl_enabled[2] = enable;
           }
           if (val & 0x0070) {
-            ipl_enabled[3] = 1;
+            ipl_enabled[3] = enable;
           }
           if (val & 0x0780) {
             ipl_enabled[4] = enable;

--- a/emulator.c
+++ b/emulator.c
@@ -1148,10 +1148,10 @@ void m68k_write_memory_16(unsigned int address, unsigned int value) {
     ps_write_8((uint32_t)address, value & 0xFF);
     ps_write_8((uint32_t)address + 1, (value >> 8) & 0xFF);
     return;
-  } else {
-    ps_write_16((uint32_t)address, value);
-    return;
   }
+
+  ps_write_16((uint32_t)address, value);
+  return;
 }
 
 void m68k_write_memory_32(unsigned int address, unsigned int value) {
@@ -1166,9 +1166,9 @@ void m68k_write_memory_32(unsigned int address, unsigned int value) {
     ps_write_16((uint32_t)address + 1, htobe16(((value >> 8) & 0xFFFF)));
     ps_write_8((uint32_t)address + 3, (value >> 24));
     return;
-  } else {
-    ps_write_16((uint32_t)address, value >> 16);
-    ps_write_16((uint32_t)address + 2, value);
-    return;
   }
+
+  ps_write_16((uint32_t)address, value >> 16);
+  ps_write_16((uint32_t)address + 2, value);
+  return;
 }

--- a/m68kcpu.h
+++ b/m68kcpu.h
@@ -1446,8 +1446,8 @@ static inline void m68ki_write_16_fc(m68ki_cpu_core *state, uint address, uint f
 #ifdef CHIP_FASTPATH
 	if (!state->ovl && address < 0x200000) {
 		if (address & 0x01) {
-			ps_write_8(value & 0xFF, address);
-			ps_write_8((value >> 8) & 0xFF, address + 1);
+			ps_write_8((uint32_t)address, value & 0xFF);
+			ps_write_8((uint32_t)address + 1, (value >> 8) & 0xFF);
 			return;
 		}
 		ps_write_16(address, value);
@@ -1490,9 +1490,9 @@ static inline void m68ki_write_32_fc(m68ki_cpu_core *state, uint address, uint f
 #ifdef CHIP_FASTPATH
 	if (!state->ovl && address < 0x200000) {
 		if (address & 0x01) {
-			ps_write_8(value & 0xFF, address);
-			ps_write_16(htobe16(((value >> 8) & 0xFFFF)), address + 1);
-			ps_write_8((value >> 24), address + 3);
+			ps_write_8((uint32_t)address, value & 0xFF);
+			ps_write_16((uint32_t)address + 1, htobe16(((value >> 8) & 0xFFFF)));
+			ps_write_8((uint32_t)address + 3, (value >> 24));
 			return;
 		}
 		ps_write_32(address, value);


### PR DESCRIPTION
I'm not sure if this is some kind of workaround or just makes it impossible to turn off the interrupts for COPER, VERTB, BLIT